### PR TITLE
Single file packes

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -261,18 +261,15 @@ const _screenshotApp = async output => {
     }
   }
 
-  builder.addExchange(primaryUrl + '/xrpackage_icon.gif', 200, {
-    'Content-Type': 'image/gif',
-  }, gifUint8Array);
-  builder.addExchange(primaryUrl + '/xrpackage_icon.glb', 200, {
-    'Content-Type': 'gltf-binary',
-  }, glbUint8Array);
-
   if (!Array.isArray(manifestJson.icons)) {
     manifestJson.icons = [];
   }
   let gifIcon = manifestJson.icons.find(icon => icon.type === 'image/gif');
   if (!gifIcon) {
+    builder.addExchange(primaryUrl + '/xrpackage_icon.gif', 200, {
+      'Content-Type': 'image/gif',
+    }, gifUint8Array);
+
     gifIcon = {
       src: 'xrpackage_icon.gif',
       'type': 'image/gif',
@@ -281,6 +278,10 @@ const _screenshotApp = async output => {
   }
   let glbIcon = manifestJson.icons.find(icon => icon.type === 'model/gltf-binary');
   if (!glbIcon) {
+    builder.addExchange(primaryUrl + '/xrpackage_icon.glb', 200, {
+      'Content-Type': 'gltf-binary',
+    }, glbUint8Array);
+
     glbIcon = {
       src: 'xrpackage_icon.glb',
       'type': 'model/gltf-binary',

--- a/cli.js
+++ b/cli.js
@@ -810,7 +810,7 @@ yargs
             const hasStartUrl = typeof j.start_url === 'string';
             if (hasXrType && hasStartUrl) {
               xrType = j.xr_type;
-              startUrl = j.start_url;
+              startUrl = j.start_url.replace(/(?:\?|\#).*$/, '');
               mimeType = xrTypeToMimeType[xrType] || 'application/octet-stream';
               fileInput = path.join(path.dirname(input), startUrl);
               description = 'Directory package';

--- a/cli.js
+++ b/cli.js
@@ -862,12 +862,15 @@ yargs
           const _recurse = d => {
             const filenames = fs.readdirSync(d);
             for (let i = 0; i < filenames.length; i++) {
-              const filename = path.join(d, filenames[i]);
-              const stats = fs.lstatSync(filename);
-              if (stats.isFile()) {
-                result.push(filename.slice(rootDirectory.length).replace( /\\/g, '/' ) );
-              } else if (stats.isDirectory()) {
-                _recurse(filename);
+              const filename = filenames[i];
+              if (filename !== '.git') {
+                const pathname = path.join(d, filename);
+                const stats = fs.lstatSync(pathname);
+                if (stats.isFile()) {
+                  result.push(pathname.slice(rootDirectory.length).replace(/\\/g, '/'));
+                } else if (stats.isDirectory()) {
+                  _recurse(pathname);
+                }
               }
             }
           };

--- a/cli.js
+++ b/cli.js
@@ -986,6 +986,38 @@ yargs
       throw 'missing input file';
     }
   })
+  .command('headers [input] [path]', 'print headers for file inside .wbn to stdout', yargs => {
+    yargs
+      .positional('input', {
+        describe: 'input .wbn file',
+        // default: 5000
+      })
+      .positional('path', {
+        describe: 'file path inside the .wbn to print headers for',
+        // default: 5000
+      });
+  }, async argv => {
+    handled = true;
+
+    if (argv.input) {
+      if (argv.path) {
+        const d = fs.readFileSync(argv.input);
+        const bundle = new wbn.Bundle(d);
+        const p = path.normalize(path.join('/', argv.path));
+        const u = bundle.urls.find(u => new url.URL(u).pathname === p);
+        if (u) {
+          const res = bundle.getResponse(u);
+          console.log(JSON.stringify(res.headers, null, 2));
+        } else {
+          throw `file not found: ${argv.path}`;
+        }
+      } else {
+        throw 'missing path';
+      }
+    } else {
+      throw 'missing input file';
+    }
+  })
   .command('extract [input]', 'extract contents of .wbn file', yargs => {
     yargs
       .positional('input', {

--- a/cli.js
+++ b/cli.js
@@ -954,14 +954,14 @@ yargs
       console.warn('missing input file');
     }
   })
-  .command('cat [input] [path]', 'cat contents of file inside a .wbn to stdout', yargs => {
+  .command('cat [input] [path]', 'cat contents of file inside .wbn to stdout', yargs => {
     yargs
       .positional('input', {
         describe: 'input .wbn file',
         // default: 5000
       })
       .positional('path', {
-        describe: 'path inside .wbn file to cat',
+        describe: 'file path inside the .wbn cat',
         // default: 5000
       });
   }, async argv => {

--- a/cli.js
+++ b/cli.js
@@ -870,7 +870,7 @@ yargs
             if (!/^\.git\//.test(pathname)) {
               const stats = fs.lstatSync(pathname);
               if (stats.isFile()) {
-                result.push(pathname);
+                result.push('/' + pathname);
               }
             }
           }

--- a/cli.js
+++ b/cli.js
@@ -261,32 +261,39 @@ const _screenshotApp = async output => {
     }
   }
 
-  if (!Array.isArray(manifestJson.icons)) {
-    manifestJson.icons = [];
-  }
-  let gifIcon = manifestJson.icons.find(icon => icon.type === 'image/gif');
-  if (!gifIcon) {
-    builder.addExchange(primaryUrl + '/xrpackage_icon.gif', 200, {
-      'Content-Type': 'image/gif',
-    }, gifUint8Array);
+  if (gifUint8Array.length > 0) {
+    let gifIcon = manifestJson.icons && manifestJson.icons.find(icon => icon.type === 'image/gif');
+    if (!gifIcon) {
+      builder.addExchange(primaryUrl + '/xrpackage_icon.gif', 200, {
+        'Content-Type': 'image/gif',
+      }, gifUint8Array);
 
-    gifIcon = {
-      src: 'xrpackage_icon.gif',
-      'type': 'image/gif',
-    };
-    manifestJson.icons.push(gifIcon);
+      gifIcon = {
+        src: 'xrpackage_icon.gif',
+        'type': 'image/gif',
+      };
+      if (!Array.isArray(manifestJson.icons)) {
+        manifestJson.icons = [];
+      }
+      manifestJson.icons.push(gifIcon);
+    }
   }
-  let glbIcon = manifestJson.icons.find(icon => icon.type === 'model/gltf-binary');
-  if (!glbIcon) {
-    builder.addExchange(primaryUrl + '/xrpackage_icon.glb', 200, {
-      'Content-Type': 'gltf-binary',
-    }, glbUint8Array);
+  if (glbUint8Array.length > 0) {
+    let glbIcon = manifestJson.icons && manifestJson.icons.find(icon => icon.type === 'model/gltf-binary');
+    if (!glbIcon) {
+      builder.addExchange(primaryUrl + '/xrpackage_icon.glb', 200, {
+        'Content-Type': 'gltf-binary',
+      }, glbUint8Array);
 
-    glbIcon = {
-      src: 'xrpackage_icon.glb',
-      'type': 'model/gltf-binary',
-    };
-    manifestJson.icons.push(glbIcon);
+      glbIcon = {
+        src: 'xrpackage_icon.glb',
+        'type': 'model/gltf-binary',
+      };
+      if (!Array.isArray(manifestJson.icons)) {
+        manifestJson.icons = [];
+      }
+      manifestJson.icons.push(glbIcon);
+    }
   }
 
   builder.addExchange(primaryUrl + '/manifest.json', 200, {

--- a/cli.js
+++ b/cli.js
@@ -261,8 +261,8 @@ const _screenshotApp = async output => {
     }
   }
 
-  builder.addExchange(primaryUrl + '/xrpackage_icon.png', 200, {
-    'Content-Type': 'image/png',
+  builder.addExchange(primaryUrl + '/xrpackage_icon.gif', 200, {
+    'Content-Type': 'image/gif',
   }, gifUint8Array);
   builder.addExchange(primaryUrl + '/xrpackage_icon.glb', 200, {
     'Content-Type': 'gltf-binary',
@@ -271,11 +271,11 @@ const _screenshotApp = async output => {
   if (!Array.isArray(manifestJson.icons)) {
     manifestJson.icons = [];
   }
-  let gifIcon = manifestJson.icons.find(icon => icon.type === 'image/png');
+  let gifIcon = manifestJson.icons.find(icon => icon.type === 'image/gif');
   if (!gifIcon) {
     gifIcon = {
-      src: 'xrpackage_icon.png',
-      'type': 'image/png',
+      src: 'xrpackage_icon.gif',
+      'type': 'image/gif',
     };
     manifestJson.icons.push(gifIcon);
   }

--- a/cli.js
+++ b/cli.js
@@ -866,8 +866,11 @@ yargs
             includeEmpty: false, // true to include empty dirs, default false
             follow: false, // true to follow symlink dirs, default false
           });
+          const cwd = process.cwd();
+          const outputPathname = path.resolve(cwd, argv.output);
           for (const pathname of paths) {
-            if (!/^\.git\//.test(pathname)) {
+            const fullPathname = path.resolve(cwd, pathname);
+            if (!/^\.git\//.test(pathname) && fullPathname !== outputPathname) {
               const stats = fs.lstatSync(pathname);
               if (stats.isFile()) {
                 result.push('/' + pathname);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bignumber.js": "^9.0.0",
     "btoa": "^1.2.1",
     "express": "^4.17.1",
+    "ignore-walk": "^3.0.3",
     "mime": "^2.4.4",
     "mkdirp": "^1.0.4",
     "node-blob": "0.0.2",


### PR DESCRIPTION
This PR adds support for single-file packages that include the screenshot and model icons in the `.wbn` file itself. This is as opposed to the previous strategy of using separate `wbn`, `gif`, and `glb` files.