### PR TITLE
Default output filename to the package name & actually add repo field to wbn manifest

### DIFF
--- a/commands/build.js
+++ b/commands/build.js
@@ -164,8 +164,8 @@ module.exports = {
       },
     ];
 
-    // Default to package name or a.wbn if not explicitly provided
-    argv.output = argv.output || `${name}.wbn` || 'a.wbn';
+    // Default to package name if not explicitly provided
+    argv.output = argv.output || `${name}.wbn`;
 
     // Ensure output file extension is .wbn
     if (!argv.output.endsWith('.wbn')) argv.output += '.wbn';

--- a/commands/build.js
+++ b/commands/build.js
@@ -167,9 +167,6 @@ module.exports = {
     // Default to package name if not explicitly provided
     argv.output = argv.output || `${name}.wbn`;
 
-    // Ensure output file extension is .wbn
-    if (!argv.output.endsWith('.wbn')) argv.output += '.wbn';
-
     if (directory) {
       const filenames = _readdirRecursive(directory, argv.output);
       for (let i = 0; i < filenames.length; i++) {

--- a/commands/build.js
+++ b/commands/build.js
@@ -63,7 +63,6 @@ module.exports = {
       .positional('output', {
         describe: 'output file to write',
         type: 'string',
-        default: 'a.wbn',
       })
       .option('screenshot', {
         alias: 's',
@@ -161,6 +160,12 @@ module.exports = {
         }, null, 2),
       },
     ];
+
+    // Default to package name or a.wbn if not explicitly provided
+    argv.output = argv.output || `${name}.wbn` || 'a.wbn';
+
+    // Ensure output file extension is .wbn
+    if (!argv.output.endsWith('.wbn')) argv.output += '.wbn';
 
     if (directory) {
       const filenames = _readdirRecursive(directory, argv.output);

--- a/commands/build.js
+++ b/commands/build.js
@@ -71,7 +71,7 @@ module.exports = {
       });
   },
   handler: async argv => {
-    let fileInput, startUrl, xrType, xrDetails, mimeType, name, description, directory;
+    let fileInput, startUrl, xrType, xrDetails, mimeType, name, description, repository, directory;
     const _detectType = input => {
       const type = xrTypes.find(type => type.regex.test(input));
       if (type) {
@@ -82,6 +82,7 @@ module.exports = {
         mimeType = xrTypeToMimeType[xrType];
         name = path.basename(input);
         description = type.description;
+        repository = '';
         directory = null;
       } else if (/\.json$/.test(input)) {
         const s = (() => {
@@ -114,6 +115,7 @@ module.exports = {
               fileInput = path.join(path.dirname(input), _removeUrlTail(startUrl));
               name = typeof j.name === 'string' ? j.name : path.basename(path.dirname(input));
               description = 'Directory package';
+              repository = typeof j.repository === 'string' ? j.repository : '';
               directory = path.dirname(input);
             } else if (!hasXrType) {
               throw `manifest.json missing xr_type: ${input}`;
@@ -154,6 +156,7 @@ module.exports = {
         data: JSON.stringify({
           name,
           description,
+          repository,
           xr_type: xrType,
           start_url: startUrl,
           xr_details: xrDetails,


### PR DESCRIPTION
This PR:

- defaults the output filename for `build` to be the package name, if possible (closes https://github.com/webaverse/xrpackage/issues/56)
- actually adds the `repository` field to the `.wbn`'s `manifest.json` (I added the field in https://github.com/webaverse/xrpackage-cli/pull/25 but didn't realise the manifest is manually reconstructed in `build`)