### PR TITLE
Catch Puppeteer logs/errors to log in Node process & make Puppeteer browser headful

### DIFF
--- a/commands/bake.js
+++ b/commands/bake.js
@@ -1,11 +1,10 @@
 const path = require('path');
 const fs = require('fs');
 const http = require('http');
-const puppeteer = require('puppeteer');
 const express = require('express');
 const wbn = require('wbn');
 
-const {makePromise, cloneBundle} = require('../utils');
+const {makePromise, cloneBundle, newPuppeteerPage} = require('../utils');
 const {primaryUrl, port} = require('../constants');
 
 const _readIntoPromise = (type, p) => (req, res) => {
@@ -60,9 +59,7 @@ const _bakeApp = async output => {
   const connections = [];
   server.on('connection', c => connections.push(c));
   server.listen(port, async () => {
-  // DEBUG SET HEADLESS TO FALSE
-    const browser = await puppeteer.launch({headless: true});
-    const page = await browser.newPage();
+    const {browser, page} = await newPuppeteerPage();
     await page.goto(`https://xrpackage.org/bake.html?srcWbn%3Dhttp://localhost:${port}/a.wbn%26dstGif%3Dhttp://localhost:${port}/screenshot.gif%26dstVolume%3Dhttp://localhost:${port}/volume.glb%26dstAabb%3Dhttp://localhost:${port}/aabb.json`, {waitUntil: 'networkidle2'});
     await page.waitForSelector('#baked', {visible: true});
     await browser.close();

--- a/commands/volume.js
+++ b/commands/volume.js
@@ -3,9 +3,8 @@ const http = require('http');
 
 const express = require('express');
 const wbn = require('wbn');
-const puppeteer = require('puppeteer');
 
-const {makePromise, cloneBundle} = require('../utils');
+const {makePromise, cloneBundle, newPuppeteerPage} = require('../utils');
 const {primaryUrl, port} = require('../constants');
 
 const _readIntoPromise = (type, p) => (req, res) => {
@@ -53,9 +52,7 @@ const _volumeApp = async output => {
   const connections = [];
   server.on('connection', c => connections.push(c));
   server.listen(port, async () => {
-    // DEBUG SET HEADLESS TO FALSE
-    const browser = await puppeteer.launch({headless: true});
-    const page = await browser.newPage();
+    const {browser, page} = await newPuppeteerPage();
     await page.goto(`https://xrpackage.org/volume.html?srcWbn%3Dhttp://localhost:${port}/a.wbn%26dstVolume%3Dhttp://localhost:${port}/volume.glb%26dstAabb%3Dhttp://localhost:${port}/aabb.json`);
     await page.waitForSelector('#baked', {visible: true});
     await browser.close();

--- a/utils.js
+++ b/utils.js
@@ -220,7 +220,9 @@ const cloneBundle = (bundle, options = {}) => {
   return builder;
 };
 
-const newPuppeteerPage = async (headless = true) => {
+const newPuppeteerPage = async (headless = false) => {
+  // Default headless to FALSE to avoid apparent headless chrome multisampled depth buffer bug
+  // where we get the "samples out of range" error
   const browser = await puppeteer.launch({headless});
   const page = await browser.newPage();
   page.on('console', consoleObj => console.log('Page log:', consoleObj.text()));

--- a/utils.js
+++ b/utils.js
@@ -220,6 +220,15 @@ const cloneBundle = (bundle, options = {}) => {
   return builder;
 };
 
+const newPuppeteerPage = async (headless = true) => {
+  const browser = await puppeteer.launch({headless});
+  const page = await browser.newPage();
+  page.on('console', consoleObj => console.log('Page log:', consoleObj.text()));
+  page.on('pageerror', err => console.error('Page error: ', err.stack));
+  page.on('requestfailed', req => console.error('Request failed: ', req));
+  return {browser, page};
+};
+
 const screenshotApp = async output => {
   const app = express();
   app.use((req, res, next) => {
@@ -258,9 +267,7 @@ const screenshotApp = async output => {
     connections.push(c);
   });
   server.listen(port, async () => {
-    // DEBUG SET HEADLESS TO FALSE
-    const browser = await puppeteer.launch({headless: true});
-    const page = await browser.newPage();
+    const {browser, page} = await newPuppeteerPage();
     await page.goto(`https://xrpackage.org/screenshot.html?srcWbn%3Dhttp://localhost:${port}/a.wbn%26dstGif%3Dhttp://localhost:${port}/screenshot.gif`);
     await page.waitForSelector('#baked', {visible: true});
     await browser.close();
@@ -407,6 +414,7 @@ module.exports = {
   getManifestJson,
   uploadPackage,
   getContract,
+  newPuppeteerPage,
   screenshotApp,
   cloneBundle,
 


### PR DESCRIPTION
This PR:

- adds intercepts for logs in the Puppeteer browser so we can see them in the Node process
- moves puppeteer page creation logic into helper util function to reduce repetition
- makes the Puppeteer browser headful to fix https://github.com/webaverse/xrpackage/issues/112